### PR TITLE
Fix: Corrige testes do OrderSerializer e ProductSerializer

### DIFF
--- a/order/serializers/order_serializer.py
+++ b/order/serializers/order_serializer.py
@@ -1,14 +1,15 @@
 from rest_framework import serializers
 
 from product.models import Product
-from product.serializers.product_serializer import ProducSerializer
+from product.serializers.product_serializer import ProductSerializer
+
 
 class OrderSerializer(serializers.ModelSerializer):
-    product = ProducSerializer(required=True, many=True)
+    product = ProductSerializer(required=True, many=True)
     total = serializers.SerializerMethodField()
 
-    def get_total(self, instance)
-        total = sun([product.price for product in instance.product.all ()])
+    def get_total(self, instance):
+        total = sum([product.price for product in instance.product.all()])
         return total
     class Meta:
         model = Product

--- a/order/test/test_serializer.py
+++ b/order/test/test_serializer.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from django.contrib.auth.models import User
+from product.models.category import Category
+from product.models.product import Product
+from order.serializers.order_serializer import OrderSerializer
+from order.models import Order
+
+class OrderSerializerTest(TestCase):
+    def test_order_serializer_returns_expected_fields(self):
+        user = User.objects.create_user(
+            username='testuser', 
+            email='test@example.com',
+            password='testpass123'
+        )
+        
+        category = Category.objects.create(title="Books")
+        product = Product.objects.create(title="Django 101", price=50)
+        product.category.set([category])  
+        order = Order.objects.create(user=user) 
+        order.product.set([product])  
+
+        serializer = OrderSerializer(order)
+        self.assertIn('product', serializer.data)
+        self.assertIn('total', serializer.data)

--- a/product/serializers/__init__.py
+++ b/product/serializers/__init__.py
@@ -1,2 +1,2 @@
-from product.models.product import ProductSerializer
-from product.models.category import CategorySerializer
+from .product_serializer import ProductSerializer
+from .category_serializer import CategorySerializer

--- a/product/serializers/category_serializer.py
+++ b/product/serializers/category_serializer.py
@@ -1,10 +1,9 @@
 from rest_framework import serializers
-
 from product.models.category import Category
 
-class ProductSerializer(serializers.ModelSerializer):
+class CategorySerializer(serializers.ModelSerializer):
     class Meta:
-        model = Categoryt
+        model = Category
         fields = [
             'title',
             'slug',

--- a/product/serializers/product_serializer.py
+++ b/product/serializers/product_serializer.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
-
 from product.models.product import Product
 from product.serializers.category_serializer import CategorySerializer
 
+
 class ProductSerializer(serializers.ModelSerializer):
     category = CategorySerializer(required=True, many=True)
-
+   
     class Meta:
         model = Product
         fields = [

--- a/product/tests/test_serializer.py
+++ b/product/tests/test_serializer.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from product.models.category import Category
+from product.models.product import Product
+from product.serializers.product_serializer import ProductSerializer
+
+class ProductSerializerTest(TestCase):
+    def test_product_serializer_returns_expected_fields(self):
+        category = Category.objects.create(title="Books")
+        product = Product.objects.create(title="Django 101", price=50)
+        product.category.set([category])  
+
+        serializer = ProductSerializer(product)
+        self.assertIn('title', serializer.data)
+        self.assertIn('price', serializer.data)
+        self.assertIn('category', serializer.data)


### PR DESCRIPTION
- Adiciona user obrigatório na criação de Order no teste
- Corrige erro de digitação 'sun' para 'sum' no OrderSerializer
- Ajusta teste do ProductSerializer para verificar campo 'title' ao invés de 'name'
- Todos os testes agora passam com sucesso