### PR TITLE
feat: Permite acesso público para leitura de produtos

### DIFF
--- a/product/tests/test_viewsets/test_product_viewset.py
+++ b/product/tests/test_viewsets/test_product_viewset.py
@@ -15,14 +15,17 @@ class TestProductViewSet(APITestCase):
     def setUp(self):
         self.user = UserFactory()
         self.client = APIClient()
-        self.client.force_authenticate(user=self.user)
-
+                
         self.product = ProductFactory(
             title='pro controller',
             price=200.00,
         )
 
     def test_get_all_product(self):
+        """
+        Teste de listagem - PÚBLICO (sem autenticação)
+        """
+               
         response = self.client.get(
             reverse('product-list', kwargs={'version': 'v1'})
         )
@@ -35,21 +38,24 @@ class TestProductViewSet(APITestCase):
         self.assertEqual(product_data['results'][0]['active'], self.product.active)
         
     def test_create_product(self):
+        """
+        Teste de criação - REQUER AUTENTICAÇÃO
+        """
+       
+        self.client.force_authenticate(user=self.user)
+        
         category = CategoryFactory()
         data = json.dumps({
             'title': 'notebook',
             'price': 800.00,
-            'categories_id': [ category.id]
+            'categories_id': [category.id]
         })
-
 
         response = self.client.post(
             reverse('product-list', kwargs={'version': 'v1'}),
             data=data,
             content_type='application/json'
         )
-
-
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 

--- a/product/viewsets/product_viewset.py
+++ b/product/viewsets/product_viewset.py
@@ -1,6 +1,6 @@
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication, TokenAuthentication
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 from product.models import Product
 from product.serializers.product_serializer import ProductSerializer
@@ -8,7 +8,7 @@ from product.serializers.product_serializer import ProductSerializer
 
 class ProductViewSet(ModelViewSet):
     authentication_classes = [SessionAuthentication, BasicAuthentication, TokenAuthentication]
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = ProductSerializer
 
     def get_queryset(self):


### PR DESCRIPTION
- Alterada permissão de IsAuthenticated para IsAuthenticatedOrReadOnly
- Produtos agora são acessíveis publicamente (GET)
- Criação/edição/exclusão ainda requer autenticação
- Testes ajustados para validar acesso público